### PR TITLE
Fix for error when user mention the bot

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -46,7 +46,7 @@ module.exports = class {
 
         // Check if the bot was mentionned
         if(message.content.match(new RegExp(`^<@!?${client.user.id}>( |)$`))){
-            return message.reply(language.get("PREFIX_INFO", guild.prefix || ""));
+            return message.reply(language.get("PREFIX_INFO", data.guild.prefix || ""));
         }
 
         if(message.content === "@someone" && message.guild){


### PR DESCRIPTION
**Please describe the changes this pull request makes and why it should be merged:**

Fixing an error when bot gets mention in a guild

Error:
ReferenceError: guild is not defined

**Status:**

- [x] Code changes have been tested
- [x] Code changes work without errors

**Content of the pull request:**  

- [x] This pull request changes the bot
  - [ ] This pull request includes breaking changes for the bot
  - [ ] This pull request includes new command(s) for the bot

- [ ] This pull request changes the dashboard

- [ ] This pull request **only** includes non-code changes, like changes to templates, README.md, languages, etc.
