### PR TITLE
fix: check if target is nil

### DIFF
--- a/commands/General/invitations.js
+++ b/commands/General/invitations.js
@@ -24,6 +24,7 @@ class Invitations extends Command {
     async run (message, args, data) {
 
         let member = await this.client.resolveMember(args[0]);
+        if (!member) member = message.member;
 
         // Gets the invites
         let invites = await message.guild.fetchInvites().catch((err) => {});


### PR DESCRIPTION
**Please describe the changes this pull request makes and why it should be merged:**
If the target member is nil (null or undefined), Message#member is taken into account instead.

*Fixes #176

**Status:**

- [x] Code changes have been tested
- [x] Code changes work without errors

**Content of the pull request:**  

- [x] This pull request changes the bot
  - [ ] This pull request includes breaking changes for the bot
  - [ ] This pull request includes new command(s) for the bot

- [ ] This pull request changes the dashboard

- [ ] This pull request **only** includes non-code changes, like changes to templates, README.md, languages, etc.
