### PR TITLE
Use filter user bot insteadof filter client id

### DIFF
--- a/commands/Music/skip.js
+++ b/commands/Music/skip.js
@@ -42,7 +42,7 @@ class Skip extends Command {
             return message.channel.send(message.language.get("SKIP_ERR_NO_SONG"));
         }
 
-        let members = voice.members.filter((m) => m.id !== message.client.user.id);
+        let members = voice.members.filter((m) => !m.user.bot);
 
         let embed = new Discord.MessageEmbed()
             .setAuthor(message.language.get("SKIP_TITLE"))


### PR DESCRIPTION
Because bots can't react for skip song if has many bot in channel

**Please describe the changes this pull request makes and why it should be merged:**


**Status:**

- [ ] Code changes have been tested
- [ ] Code changes work without errors

**Content of the pull request:**  

- [x] This pull request changes the bot
  - [ ] This pull request includes breaking changes for the bot
  - [ ] This pull request includes new command(s) for the bot

- [ ] This pull request changes the dashboard

- [ ] This pull request **only** includes non-code changes, like changes to templates, README.md, languages, etc.
