### PR TITLE
Use the guild language at the dashboard (only @ manager)

### DIFF
--- a/dashboard/routes/guild-manager.js
+++ b/dashboard/routes/guild-manager.js
@@ -17,7 +17,9 @@ router.get("/:serverID", CheckAuth, async(req, res) => {
 
 	// Fetch guild informations
 	const guildInfos = await utils.fetchGuild(guild.id, req.client, req.user.guilds);
-
+	// Getting the guilds language from the guild object and setting this as the new language to be translated
+	req.translate = req.client.translations.get(guildInfos.language);
+	
 	res.render("manager/guild", {
 		guild: guildInfos,
 		user: req.userInfos,


### PR DESCRIPTION


**Please describe the changes this pull request makes and why it should be merged:**
This will fix the issue where it was looking to locale of the user instead of the guilds set language.
I believe this will be better in general and will be more userfriendly.
I was re-writing the code for the dashboard and thought better PR this to here 👍 

**Status:**

- [x] Code changes have been tested
- [x] Code changes work without errors

**Content of the pull request:**  

- [ ] This pull request changes the bot
  - [ ] This pull request includes breaking changes for the bot
  - [ ] This pull request includes new command(s) for the bot

- [x] This pull request changes the dashboard

- [ ] This pull request **only** includes non-code changes, like changes to templates, README.md, languages, etc.

Example:
The below log is checking for the req.translate before changing it (before it was tr-TR after change it goes to en-EN and vs from en-EN to tr-TR see second gif for visual example)
![image](https://user-images.githubusercontent.com/25463237/114891954-9fa32f00-9e0c-11eb-879c-dcc15542e21c.png)
**Ignore the dashboard lay-out it is custom made but the code is same**
![image2](https://i.gyazo.com/8122e07c45fc7a5da9da36415fcf593d.gif)