### PR TITLE
chore: repoint Dependabot at master, drop stale ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,5 @@ updates:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
-  target-branch: develop
   reviewers:
   - Androz2091
-  ignore:
-  - dependency-name: i18next
-    versions:
-    - 20.1.0
-    - 20.2.0
-  - dependency-name: "@sentry/node"
-    versions:
-    - 6.2.1
-    - 6.2.2
-    - 6.2.5
-  - dependency-name: "@discordjs/opus"
-    versions:
-    - 0.5.0


### PR DESCRIPTION
## What

- Remove `target-branch: develop` from `.github/dependabot.yml` so Dependabot targets the repo default branch (`master`).
- Drop the obsolete `ignore` rules pinning 2021-era versions (i18next 20.1/20.2, `@sentry/node` 6.2.x, `@discordjs/opus` 0.5.0).

## Why

The config hard-coded `target-branch: develop`. But `develop` is **31 commits behind `master`** and was last updated **May 2021**. Every Dependabot PR was therefore opened against a dead branch, with diffs computed against pre-v5 code — useless against the TypeScript rewrite now on `master`.

The 8 stale PRs that targeted `develop` (#811–#818) are being closed separately. With this change, Dependabot will reopen fresh, relevant PRs against the current codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)